### PR TITLE
Removes illuminate/filesystem from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": ">=7.1",
-        "illuminate/filesystem": "5.5.*",
         "laravel-zero/framework": "4.0.*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Since `illuminate/filesystem` is a default dependency of Laravel Zero you don't need to include it on your project.